### PR TITLE
Add comment post time

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,13 @@ raw_comments = vodchat.raw
 for comment in comments:
     name = comment.name
     timestamp = comment.timestamp
+    posted_at = comment.posted_at
     message = comment.message
 
 # 2. via simple tuple unpacking
-for timestamp, name, message in comments:
+for timestamp, posted_at, name, message in comments:
     # process comment data
-    print(timestamp, name, message)
+    print(timestamp, posted_at, name, message)
 
 # if you want to access the VODChat comments again at a later date,
 # but do not want to fetch them again from the API,

--- a/docs/pyvod_changelog.md
+++ b/docs/pyvod_changelog.md
@@ -1,6 +1,24 @@
 # Changelog
 
-Changes are listed here. The latest version is currently v0.1.0.
+Changes are listed here. The latest version is currently v0.2.0.
+
+## v0.2.0 (21.05.2021)
+
+- added additional comment information `posted_at`:
+    - when the comment has been posted in the chat, in relation to the VOD/stream length
+    - `hours:minutes:seconds` format
+    
+    You can access it like the other
+    **[VODSimpleComment](https://github.com/sixP-NaraKa/pyvod-chat/blob/main/docs/pyvod_documentation.md#class-vodsimplecomment)**
+    attributes:
+        
+```python
+for comment in vod_comments:
+    # print(comment.timestamp)
+    print(comment.posted_at)
+    # print(comment.name)
+    # print(comment.message)
+```
 
 ## v0.1.0 (20.04.2021)
 

--- a/docs/pyvod_documentation.md
+++ b/docs/pyvod_documentation.md
@@ -37,33 +37,51 @@ The main entry point, is  responsible for getting the [VODChat](https://github.c
 
 This class also has additional information about the VOD itself and its associated channel.
 
-Parameters:
+##### Parameters:
 - `vod_id`: 
     
     the VOD ID to fetch the information for
 
-Additional Class Attributes:
+##### Additional Class Attributes:
 
-    The following are class attributes which contain basic information about the VOD and its associated channel.
+The following are class attributes which contain basic information about the VOD and its associated channel.
 
-    - vod_title:
-                the title of the VOD
-    - vod_length:
-                the length of the VOD in hours
-    - vod_date:
-                the date when the broadcast has been streamed
-    - vod_views:
-                the total amount of VOD views
-    - channel:
-                the name of the channel associated with the VOD
-    - channel_id:
-                the channel ID
-    - channel_views:
-                total channel views
-    - channel_followers:
-                total channel followers
-    - channel_broadcaster_type:
-                whether the channel is partnered or a affiliate
+- `vod_title`:
+    
+    the title of the VOD
+        
+- `vod_length`:
+    
+    the length of the VOD in hours
+    
+- `vod_date`:
+      
+    the date when the broadcast has been streamed
+     
+- `vod_views`:
+
+    the total amount of VOD views
+                
+- `channel`:
+
+    the name of the channel associated with the VOD
+                
+- `channel_id`:
+
+    the channel ID
+                
+- `channel_views`:
+
+    total channel views
+                
+- `channel_followers`:
+
+    total channel followers
+                
+- `channel_broadcaster_type`:
+
+    whether the channel is partnered or a affiliate
+                
 
 ### available methods
 
@@ -79,7 +97,7 @@ A class which represents the VOD stream chat. We store here both the 'raw commen
 
 There should be no need to create a instance of this class manually.
 
-Parameters:
+##### Parameters:
 - `vod_id`: 
     
     the VOD ID to fetch the information for
@@ -94,16 +112,19 @@ with the given VOD and its channel owner
     the required request headers to authenticate with the Twitch API
     
     
-Additional Class Attributes
+##### Additional Class Attributes:
 
-    The following are class attributes which contain basic information about the VOD and its associated channel.
+- `vod_comments`:
 
-    - vod_comments:
-                the VOD comments contain the name, message and timestamp of a comment (class VODSimpleComment)
-    - raw_comments:
-                the raw comments in JSON
-    - url:
-                the base url for the VOD requests
+    the VOD comments contain the name, message and timestamp of a comment (class VODSimpleComment)
+
+- `raw_comments`:
+
+    the raw comments in JSON
+
+- `url`:
+
+    the base url for the VOD requests
 
 
 ### available methods
@@ -119,7 +140,7 @@ Additional Class Attributes
     
 - `def get_comments() -> list:`
     
-    "cleans" the raw_comments. Meaning: user name, when it was posted, and the body/text of the chat comment.
+    "cleans" the raw_comments. Meaning: timestamp, user name, when the message has been posted in the chat and the body/text of the chat comment.
     Returns the comments. Each comment is a **[VODSimpleComment](https://github.com/sixP-NaraKa/pyvod-chat/blob/main/docs/pyvod_documentation.md#class-vodsimplecomment)** object.
 
     If the raw data is wanted (JSON),
@@ -160,6 +181,10 @@ Each VODSimpleComment instance consists of:
 
 - the `timestamp` of the message
 
+- the `posted_at` time (when in the VOD the comment has been posted)
+            
+            -> added in v0.2.0
+
 - the `name` of the user who wrote the message
 
 - the `message` body
@@ -172,6 +197,7 @@ Like so:
 
 for comment in vod_comments:
     print(comment.timestamp)
+    print(comment.posted_at)
     print(comment.name)
     print(comment.message)
 ```

--- a/pyvod/vod.py
+++ b/pyvod/vod.py
@@ -108,7 +108,7 @@ class VOD:
         data = BasicData(
             response_body["title"],                      # VOD title
             response_body["views"],                      # VOD views
-            response_body["created_at"][:10],            # VOD stream date
+            response_body["created_at"],            # VOD stream date
             response_body["game"],                       # what game has been streamed
             response_body["length"],                     # VOD length in seconds (seconds / 3600 = hours)
             response_body["channel"]["display_name"],    # channel name (streamer name)

--- a/pyvod/vodcomment.py
+++ b/pyvod/vodcomment.py
@@ -15,6 +15,9 @@ class VODSimpleComment(NamedTuple):
 
         - the `timestamp` of the message
 
+        - the `posted_at` time (when in the VOD the comment has been posted)
+            -> added in v0.2.0
+
         - the `name` of the user who wrote the message
 
         - the `message` body
@@ -23,8 +26,9 @@ class VODSimpleComment(NamedTuple):
     """
 
     timestamp: str
+    posted_at: str
     name: str
     message: str
 
     def __repr__(self):
-        return "<VODComment timestamp={0.timestamp!r} name={0.name!r} message={0.message!r}>".format(self)
+        return "<VODComment timestamp={0.timestamp!r} posted_at={0.posted_at!r} name={0.name!r} message={0.message!r}>".format(self)


### PR DESCRIPTION
- additional comment information, when exactly the message has been posted in the VOD/stream chat ("hours:minutes:seconds" format)
- this new VODSimpleComment attribute "posted_at" can be accessed the same as the other class attributes, like so:

```python
for comment in vod_comments:
    # print(comment.timestamp)
    print(comment.posted_at)
    # print(comment.name)
    # print(comment.message)
```

Closes #1 