### PR TITLE
ISSUE #3: fix strptime format error if given datime string contains

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ vodchat = vod.get_vodchat()  # get a VODChat instance, contains the VOD chat
 
 # fetches the comments from the VOD
 # this returns a list containing VODSimpleComment (NamedTuple) objects,
-# which only contain the 'name', 'timestamp' and 'message' of a comment
+# which only contain the 'name', 'timestamp', when the message has been posted and
+# the 'message' content of a comment
 comments = vodchat.get_comments()
 
 # if the raw comment data (JSON) is needed, simply fetch them like so

--- a/pyvod/utils.py
+++ b/pyvod/utils.py
@@ -6,6 +6,7 @@ Available on GitHub (+ documentation): https://github.com/sixP-NaraKa/pyvod-chat
 
 
 import pathlib
+from datetime import datetime
 
 from .exceptions import DirectoryDoesNotExistError, DirectoryIsAFileError
 
@@ -29,3 +30,22 @@ def validate_path(provided_path: str) -> pathlib.Path:
     provided_path = path
 
     return provided_path
+
+
+def get_strptime(datetime_string: str) -> datetime:
+    """ Helper function which parses a valid datetime object out of a given datetime string (with a predefined format).
+
+        :param datetime_string: the string to parse the datetime object from
+        :return: the valid datetime object
+    """
+
+    if "." in datetime_string:
+        split = datetime_string.split(".")
+        microsecond_split = split[1]
+        # 8 because 6 are max. for the datetime.strptime() %f's (microseconds) format code, and 1 is the Z character
+        if len(microsecond_split) > 8:
+            split[1] = microsecond_split[:6] + "Z"
+        datetime_string = ".".join(split)
+        return datetime.strptime(datetime_string, "%Y-%m-%dT%H:%M:%S.%fZ")
+    else:
+        return datetime.strptime(datetime_string, "%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
more than the expected 6 microsecond digits (%f format code).

For example, as mentioned in issue #3: 

`ValueError: time data '2021-09-09T20:15:52.40990439Z' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'`

- that is because the datetime string '2021-09-09T20:15:52.40990439Z' contains too many microsecond digits **.40990439Z** for the `datetime.strptime()` function

This **fix** simply checks for such a higher number of microsecond digits, and simply cuts them off (as they shouldn't be there anyway, might be a Twitch API thing? Never encountered it before here):

```python

def get_strptime(datetime_string: str) -> datetime:
    if "." in datetime_string:
        split = datetime_string.split(".")
        microsecond_split = split[1]
        # 8 because 6 are max. for the datetime.strptime() %f's (microseconds) format code, and 1 is the Z character
        if len(microsecond_split) > 8:
            split[1] = microsecond_split[:6] + "Z"
        datetime_string = ".".join(split)
        return datetime.strptime(datetime_string, "%Y-%m-%dT%H:%M:%S.%fZ")
    else:
        return datetime.strptime(datetime_string, "%Y-%m-%dT%H:%M:%SZ")

s = "2021-09-09T20:15:52.40990439Z"
d = get_strptime(datetime_string=s)

print(d)  # --> 2021-09-09 20:15:52.409904

```


The end result of this fix is essentially the same as the _proposed solution_ of using the `dateutil.parse()` 3rd party package functionality in #3:

```python

from dateutil.parser import parse

s = "2021-09-09T20:15:52.40990439Z"
d = parse(timestr=s, ignoretz=True)  # or use d.replace(tzinfo=None)

print(d)  # --> 2021-09-09 20:15:52.409904

```

The reason for not using the 3rd party library functionality is simple:

- since this is a very minor issue and simple to fix, there is no need to use a separate library for just these simple use-cases (in this case 2 use-cases) and hence add a dependency